### PR TITLE
Remove newline before return in README code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,4 @@ int main()
             printf("%dは奇数である\n", a[i]);
         }
     }
-    return 0;
-}
+    return 0;}


### PR DESCRIPTION
Fix formatting issue by removing newline before return statement.